### PR TITLE
add mimetype installation method to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ inkscape:
 mime-register:
 	xdg-icon-resource install --context mimetypes --size 512 pd-512.png x-puredata
 	xdg-mime install x-puredata.xml
-	cp pd-gui.desktop ~/.local/share/applications.pd-gui.desktop
+	cp pd-gui.desktop ~/.local/share/applications/pd-gui.desktop
 
 clean:
 	rm -f $(ICO) $(FILE) $(ICNS) $(ICONSET) $(GIF) $(XPM) pd-*.png

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ mime-register:
 	xdg-icon-resource install --context mimetypes --size 512 pd-512.png x-puredata
 	xdg-mime install x-puredata.xml
 	cp pd-gui.desktop ~/.local/share/applications/pd-gui.desktop
+# 	following https://hoppenheit.info/blog/2016/where-to-put-application-icons-on-linux/
+
+install:
+	cp tweaked/pd.xpm /usr/share/pixmaps/puredata.xpm
+	cp pd-48.png /usr/share/icons/hicolor/48x48/apps/puredata.png
+	cp masters/icon.svg /usr/share/icons/hicolor/scalable/apps/puredata.svg
 
 clean:
 	rm -f $(ICO) $(FILE) $(ICNS) $(ICONSET) $(GIF) $(XPM) pd-*.png

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 # Max Neupert 2021
 # 
 
+prefix = /usr/local
+datarootdir = $(prefix)/share
+#$(DESTDIR) = 
+
 UNAME = $(shell uname)
 
 NAME=pd
@@ -99,13 +103,14 @@ inkscape:
 mime-register:
 	xdg-icon-resource install --context mimetypes --size 512 pd-512.png x-puredata
 	xdg-mime install x-puredata.xml
-	cp pd-gui.desktop ~/.local/share/applications/pd-gui.desktop
+	cp pd-gui.desktop $(DESTDIR)$(datarootdir)/applications/pd-gui.desktop
+
 
 # 	following https://hoppenheit.info/blog/2016/where-to-put-application-icons-on-linux/
 install:
-	cp tweaked/pd.xpm /usr/share/pixmaps/puredata.xpm
-	cp pd-48.png /usr/share/icons/hicolor/48x48/apps/puredata.png
-	cp masters/icon.svg /usr/share/icons/hicolor/scalable/apps/puredata.svg
+	cp tweaked/pd.xpm $(DESTDIR)/usr/share/pixmaps/puredata.xpm
+	cp pd-48.png $(DESTDIR)$(datarootdir)/icons/hicolor/48x48/apps/puredata.png
+	cp masters/icon.svg $(DESTDIR)$(datarootdir)/icons/hicolor/scalable/apps/puredata.svg
 
 clean:
 	rm -f $(ICO) $(FILE) $(ICNS) $(ICONSET) $(GIF) $(XPM) pd-*.png

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #
 # Dan Wilcox <danomatika@gmail.com> 2017
+# Max Neupert 2021
 # 
 
 UNAME = $(shell uname)
@@ -93,6 +94,11 @@ inkscape:
 	for _res in 16 32 48 64 96 128 256 512 ; do \
 		 inkscape --export-type="png" --export-filename=pd-$${_res}.png --export-width $${_res} --export-height $${_res} $(SRC_SVG) ; \
 	done
+
+# register icon for Pd mimetype (adapted from https://stackoverflow.com/a/31836/1964109 )
+mime-register:
+	xdg-icon-resource install --context mimetypes --size 512 pd-512.png x-puredata
+	xdg-mime install x-puredata.xml 
 
 clean:
 	rm -f $(ICO) $(FILE) $(ICNS) $(ICONSET) $(GIF) $(XPM) pd-*.png

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,8 @@ inkscape:
 # register icon for Pd mimetype (adapted from https://stackoverflow.com/a/31836/1964109 )
 mime-register:
 	xdg-icon-resource install --context mimetypes --size 512 pd-512.png x-puredata
-	xdg-mime install x-puredata.xml 
+	xdg-mime install x-puredata.xml
+	cp pd-gui.desktop ~/.local/share/applications.pd-gui.desktop
 
 clean:
 	rm -f $(ICO) $(FILE) $(ICNS) $(ICONSET) $(GIF) $(XPM) pd-*.png

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ mime-register:
 	xdg-icon-resource install --context mimetypes --size 512 pd-512.png x-puredata
 	xdg-mime install x-puredata.xml
 	cp pd-gui.desktop ~/.local/share/applications/pd-gui.desktop
-# 	following https://hoppenheit.info/blog/2016/where-to-put-application-icons-on-linux/
 
+# 	following https://hoppenheit.info/blog/2016/where-to-put-application-icons-on-linux/
 install:
 	cp tweaked/pd.xpm /usr/share/pixmaps/puredata.xpm
 	cp pd-48.png /usr/share/icons/hicolor/48x48/apps/puredata.png

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Additionally, you can generate a set of pd-#.png at different resolutions direct
 
 For the default font to render, you will need DejaVu Sans Mono installed.
 
+Linux icon install
+------------------
+
+To register and install the mimetype type:
+
+    make mime-register
+
+
 Testing and Updated Icon in Pd
 ------------------------------
 

--- a/pd-gui.desktop
+++ b/pd-gui.desktop
@@ -1,8 +1,12 @@
 [Desktop Entry]
-Exec=/usr/local/bin/pd-gui
+Name=Pure Data
+Exec=pd-gui
+Categories=Audio;Multimedia;
+Keywords=pd;puredata;
+Comment=Dataflow and DSP Programming Environment
 MimeType=text/x-puredata;
-Name=pd-gui
-NoDisplay=true
+GenericName=Dataflow IDE
+NoDisplay=false
 Type=Application
 Terminal=false
 Icon=puredata

--- a/pd-gui.desktop
+++ b/pd-gui.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Exec=/usr/local/bin/pd-gui
+MimeType=text/x-puredata;
+Name=pd-gui
+NoDisplay=true
+Type=Application
+Terminal=false
+Icon=puredata

--- a/x-puredata.xml
+++ b/x-puredata.xml
@@ -1,0 +1,65 @@
+ <!-- Original by Albert Graef: https://github.com/pd-l2ork/pd/blob/master/debuild/debian/sharedmimeinfo -->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/x-puredata">
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.pd"/>
+	<alias type="application/x-puredata"/>
+	<magic priority="50">
+	  <match type="string" value="#N " offset="0"/>
+	</magic>
+    <comment>Pure Data Document</comment>
+	<comment xml:lang="en">Pure Data Document</comment>
+	<comment xml:lang="de">Pure Data Dokument</comment>
+	<comment xml:lang="cy">Dogfen Pure Data</comment>
+	<comment xml:lang="nb">Pure Data-dokument</comment>
+	<comment xml:lang="nn">Pure Data-dokument</comment>
+	<comment xml:lang="fi">Pure Data-asiakirja</comment>
+	<comment xml:lang="cz">Pure Data Dokument</comment>
+	<comment xml:lang="sl">Dokument Pure Data</comment>
+	<comment xml:lang="fr">Pure Data Document</comment>
+	<comment xml:lang="es">Documento de Pure Data</comment>
+	<comment xml:lang="it">Documento Pure Data</comment>
+	<comment xml:lang="nb">Pure Data dokument</comment>
+	<comment xml:lang="da">Pure Data Dokument</comment>
+	<comment xml:lang="tr">Pure Data Belgesi</comment>
+	<comment xml:lang="ru">Документ Pure Data</comment>
+  </mime-type>
+  <mime-type type="text/x-puredata-help">
+    <sub-class-of type="text/x-puredata"/>
+    <glob pattern="*-help.pd"/>
+    <comment>Pure Data Help</comment>
+  </mime-type>
+  <mime-type type="text/x-puredata-meta">
+    <sub-class-of type="text/x-puredata"/>
+    <glob pattern="*-meta.pd"/>
+    <comment>Pure Data Meta Marker for Libraries</comment>
+  </mime-type>
+  <mime-type type="application/x-puredata-external-linux">
+    <sub-class-of type="application/octet-stream"/>
+    <glob pattern="*.pd_linux"/>
+    <comment>Pure Data External (Linux Binary)</comment>
+  </mime-type>
+  <mime-type type="application/x-puredata-external-darwin">
+    <sub-class-of type="application/octet-stream"/>
+    <glob pattern="*.pd_darwin"/>
+    <comment>Pure Data External (Mac OS X Binary)</comment>
+  </mime-type>
+  <mime-type type="text/x-maxmsp">
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.mxt"/>
+    <comment>Max/MSP Text Document</comment>
+	<magic priority="50">
+	  <match type="string" value="max v2;" offset="0"/>
+	</magic>
+  </mime-type>
+  <mime-type type="application/x-maxmsp">
+    <sub-class-of type="application/octet-stream"/>
+    <glob pattern="*.mxb"/>
+	<magic priority="50">
+	  <match type="string" value="pmax" offset="4"/>
+	</magic>
+    <comment>Max/MSP Binary Document</comment>
+  </mime-type>
+</mime-info>

--- a/x-puredata.xml
+++ b/x-puredata.xml
@@ -1,5 +1,3 @@
- <!-- Original by Albert Graef: https://github.com/pd-l2ork/pd/blob/master/debuild/debian/sharedmimeinfo -->
-
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="text/x-puredata">


### PR DESCRIPTION
this might be out of scope - or not - but it's very handy to install a x-puredata mimetype on Linux. I took the mimeinfo from  https://github.com/pd-l2ork/pd/blob/master/debuild/debian/sharedmimeinfo
and the procedure from 
https://stackoverflow.com/a/31836/1964109